### PR TITLE
home-manager/cli: use hiPrio for binutils

### DIFF
--- a/home-manager/cli.nix
+++ b/home-manager/cli.nix
@@ -3,7 +3,7 @@
 {
   home.packages = with pkgs; [
     aria2
-    binutils
+    (lib.hiPrio binutils) # fix conflict with gcc in darwin
     coreutils
     curl
     daemonize


### PR DESCRIPTION
`gcc` has a symbolic link to binutils `ld`, however Nix on Darwin, AFAIK, uses symbolic links so this causes a conflict.

They're the exactly same binary though, so using either one with higher priority should fix the issue.