### PR TITLE
github: remove installation of bash via brew

### DIFF
--- a/.github/workflows/build-and-cache.yml
+++ b/.github/workflows/build-and-cache.yml
@@ -21,6 +21,9 @@ jobs:
           fetch-depth: 0
 
       - uses: cachix/install-nix-action@v16
+        # Need to define channel, otherwise it will use bash from environment
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
 
       - uses: cachix/cachix-action@v10
         with:

--- a/.github/workflows/update-flakes-darwin.yml
+++ b/.github/workflows/update-flakes-darwin.yml
@@ -16,6 +16,9 @@ jobs:
           fetch-depth: 0
 
       - uses: cachix/install-nix-action@v16
+        # Need to define channel, otherwise it will use bash from environment
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
 
       - uses: cachix/cachix-action@v10
         with:
@@ -25,11 +28,6 @@ jobs:
 
       - name: Set default git branch (to reduce log spam)
         run: git config --global init.defaultBranch master
-
-      - name: Install up-to-date Bash
-        run: |
-          brew update
-          brew install bash
 
       - name: Build Nix configs
         run: ./Makefile all-macos

--- a/.github/workflows/update-flakes.yml
+++ b/.github/workflows/update-flakes.yml
@@ -21,6 +21,9 @@ jobs:
           fetch-depth: 0
 
       - uses: cachix/install-nix-action@v16
+        # Need to define channel, otherwise it will use bash from environment
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
 
       - uses: cachix/cachix-action@v10
         with:


### PR DESCRIPTION
Need to define a nixpkgs channel, otherwise we have the following error:

```
error: file 'nixpkgs' was not found in the Nix search path (add it using $NIX_PATH or -I)

       at «string»:1:9:

            1| (import <nixpkgs> {}).bashInteractive
             |         ^
will use bash from your environment
```